### PR TITLE
Support for X-Arcade Dualstick with USB adapter

### DIFF
--- a/src/input_xarcade.c
+++ b/src/input_xarcade.c
@@ -63,7 +63,8 @@ int findXarcadeDevice(void) {
 		}
 
 		ioctl(fevdev, EVIOCGNAME(sizeof(name)), name);
-		if (strcmp(name, "XGaming X-Arcade") == 0) {
+		if ((strcmp(name, "XGaming X-Arcade") == 0)
+		    || (strcmp(name, "XGaming USBAdapter") == 0)) {
 			printf("Found %s (%s)\n", charbuffer, name);
 			break;
 		} else {


### PR DESCRIPTION
Just tested today on last version of RetroPie after several hours trying to get it working :).
The only problem has been Player 1 & 2 coin and Player 1 & 2 start buttons, because in Mame4All are configured as different keys.

I've had to change mame.cfg for mapping mame directories to an external drive (where roms are located), then in Mame I've configured the General Input keys mapping Player 1 & 2 coin, Player 1 & 2 start to Dualstick buttons.
