### PR TITLE
Add new device name for Dec 31, 2015 X-Arcade Tankstick

### DIFF
--- a/src/input_xarcade.c
+++ b/src/input_xarcade.c
@@ -64,7 +64,8 @@ int findXarcadeDevice(void) {
 
 		ioctl(fevdev, EVIOCGNAME(sizeof(name)), name);
 		if ((strcmp(name, "XGaming X-Arcade") == 0)
-		    || (strcmp(name, "XGaming USBAdapter") == 0)) {
+		    || (strcmp(name, "XGaming USBAdapter") == 0)
+		    || (strcmp(name, "HID 1241:1122") == 0)) {
 			printf("Found %s (%s)\n", charbuffer, name);
 			break;
 		} else {


### PR DESCRIPTION
Tankstick models manufactured after Dec, 2015 identify themselves
as "HID 1241:1122"