### PR TITLE
service: Add --pidfile argument to start-stop-daemon

### DIFF
--- a/scripts/xarcade2jstick
+++ b/scripts/xarcade2jstick
@@ -45,9 +45,9 @@ do_start()
 	#   0 if daemon has been started
 	#   1 if daemon was already running
 	#   2 if daemon could not be started
-	start-stop-daemon -b --start --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
+	start-stop-daemon -b --start --quiet --pidfile $PIDFILE --make-pidfile --exec $DAEMON --test > /dev/null \
 		|| return 1
-	start-stop-daemon -b --start --quiet --pidfile $PIDFILE --exec $DAEMON -- \
+	start-stop-daemon -b --start --quiet --pidfile $PIDFILE --make-pidfile --exec $DAEMON -- \
 		$DAEMON_ARGS \
 		|| return 2
 	# Add code here, if necessary, that waits for the process to be ready


### PR DESCRIPTION
xarcade2jstick does not create its own pidfile, therefore we add this command-line argument to start-stop-daemon when starting the service, so it will create one for us.

This speeds up the stopping of the service by about 30 seconds.