### PR TITLE
Makefile: build the project before running make install

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -26,7 +26,7 @@ clean:
 
 -include $(DEPS)
 
-install:
+install: all
 	install -d $(DESTDIR)$(bindir)
 	install -m 0755 $(TARGET) $(DESTDIR)$(bindir)
 	install -d $(DESTDIR)/lib/udev/rules.d/


### PR DESCRIPTION
I believe this is common behaviour in a Makefile, that a make install will also build the project first if it needs to.