### PR TITLE
xarcade2jstick: fork after sucessfully opening a device

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -59,6 +59,11 @@ int main(int argc, char* argv[]) {
 		exit(-1);
 	}
 
+	if (daemon(0, 1)) {
+		perror("daemon");
+		return 1;
+	}
+
 	while (1) {
 		rd = input_xarcade_read(&xarcdev);
 		if (rd < 0) {


### PR DESCRIPTION
udev needs the process to return quickly so fork after initialization is done.
This should fix https://github.com/petrockblog/Xarcade2Jstick/issues/9