### PR TITLE
Fix simulated keypresses by introducing a sleep between the down and up events

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -114,6 +114,7 @@ int main(int argc, char* argv[]) {
 					/* handle combination */
 					if (keyStates[KEY_3] && xarcdev.ev[ctr].value) {
 						uinput_kbd_write(&uinp_kbd, KEY_6, 1, EV_KEY);
+						uinput_kbd_sleep();
 						uinput_kbd_write(&uinp_kbd, KEY_6, 0, EV_KEY);
 						combo = 2;
 						continue;
@@ -133,6 +134,7 @@ int main(int argc, char* argv[]) {
 					/* combination with the other side button, quit */
 					if (keyStates[KEY_3] && keyStates[KEY_4]) {
 						uinput_kbd_write(&uinp_kbd, KEY_ESC, 1, EV_KEY);
+						uinput_kbd_sleep();
 						uinput_kbd_write(&uinp_kbd, KEY_ESC, 0, EV_KEY);
 						keyStates[KEY_3] = keyStates[KEY_4] = 0;
 						combo = 2;
@@ -143,6 +145,7 @@ int main(int argc, char* argv[]) {
 						continue;
 					if (!combo) {
 						uinput_gpad_write(&uinp_gpads[0], BTN_SELECT, 1, EV_KEY);
+						uinput_gpad_sleep();
 						uinput_gpad_write(&uinp_gpads[0], BTN_SELECT, 0, EV_KEY);
 					} else
 						combo--;
@@ -209,6 +212,7 @@ int main(int argc, char* argv[]) {
 					/* handle combination */
 					if (keyStates[KEY_4] && xarcdev.ev[ctr].value) {
 						uinput_kbd_write(&uinp_kbd, KEY_7, 1, EV_KEY);
+						uinput_kbd_sleep();
 						uinput_kbd_write(&uinp_kbd, KEY_7, 0, EV_KEY);
 						combo = 2;
 						continue;
@@ -228,6 +232,7 @@ int main(int argc, char* argv[]) {
 					/* combination with the other side button, quit */
 					if (keyStates[KEY_3] && keyStates[KEY_4]) {
 						uinput_kbd_write(&uinp_kbd, KEY_ESC, 1, EV_KEY);
+						uinput_kbd_sleep();
 						uinput_kbd_write(&uinp_kbd, KEY_ESC, 0, EV_KEY);
 						keyStates[KEY_3] = keyStates[KEY_4] = 0;
 						combo = 2;
@@ -238,6 +243,7 @@ int main(int argc, char* argv[]) {
 						continue;
 					if (!combo) {
 						uinput_gpad_write(&uinp_gpads[1], BTN_SELECT, 1, EV_KEY);
+						uinput_gpad_sleep();
 						uinput_gpad_write(&uinp_gpads[1], BTN_SELECT, 0, EV_KEY);
 					} else
 						combo--;

--- a/src/uinput_gamepad.c
+++ b/src/uinput_gamepad.c
@@ -135,6 +135,6 @@ int16_t uinput_gpad_write(UINP_GPAD_DEV* const gpad, uint16_t keycode,
 
 /* sleep between immediate successive gpad writes */
 int16_t uinput_gpad_sleep() {
-	usleep(100000);
+	usleep(50000);
 	return 0;
 }

--- a/src/uinput_gamepad.c
+++ b/src/uinput_gamepad.c
@@ -132,3 +132,9 @@ int16_t uinput_gpad_write(UINP_GPAD_DEV* const gpad, uint16_t keycode,
 	}
 	return 0;
 }
+
+/* sleep between immediate successive gpad writes */
+int16_t uinput_gpad_sleep() {
+	usleep(100000);
+	return 0;
+}

--- a/src/uinput_gamepad.h
+++ b/src/uinput_gamepad.h
@@ -36,5 +36,6 @@ int16_t uinput_gpad_open(UINP_GPAD_DEV* const gpad, UINPUT_GPAD_TYPE_E type);
 int16_t uinput_gpad_close(UINP_GPAD_DEV* const gpad);
 int16_t uinput_gpad_write(UINP_GPAD_DEV* const gpad, uint16_t keycode,
 		int16_t keyvalue, uint16_t evtype);
+int16_t uinput_gpad_sleep();
 
 #endif /* UINPUT_GAMEPAD_H_ */

--- a/src/uinput_kbd.c
+++ b/src/uinput_kbd.c
@@ -92,6 +92,6 @@ int16_t uinput_kbd_write(UINP_KBD_DEV* const kbd, unsigned int keycode,
 
 /* sleep between immediate successive keyboard writes */
 int16_t uinput_kbd_sleep() {
-	usleep(100000);
+	usleep(50000);
 	return 0;
 }

--- a/src/uinput_kbd.c
+++ b/src/uinput_kbd.c
@@ -89,3 +89,9 @@ int16_t uinput_kbd_write(UINP_KBD_DEV* const kbd, unsigned int keycode,
 	}
 	return 0;
 }
+
+/* sleep between immediate successive keyboard writes */
+int16_t uinput_kbd_sleep() {
+	usleep(100000);
+	return 0;
+}

--- a/src/uinput_kbd.h
+++ b/src/uinput_kbd.h
@@ -29,5 +29,6 @@ int16_t uinput_kbd_open(UINP_KBD_DEV* const kbd);
 int16_t uinput_kbd_close(UINP_KBD_DEV* const kbd);
 int16_t uinput_kbd_write(UINP_KBD_DEV* const kbd, unsigned int keycode,
 		int keyvalue, unsigned int evtype);
+int16_t uinput_kbd_sleep();
 
 #endif /* UINPUT_KBD_H_ */


### PR DESCRIPTION
Advmame in particular expected this otherwise BTN_SELECT didn't work. I arrived at the sleep value of 100000 after some basic testing. 10000 was too short.

I'll experiment with some values between 100000 and 10000.

I've put the sleeps into the uinput files and made one for kbd and gpad respectively in case we determine that the values need to be different for them?