### PR TITLE
input_xarcade: fix return value of input_xarcade_read()

### DIFF
--- a/src/input_xarcade.c
+++ b/src/input_xarcade.c
@@ -39,7 +39,7 @@ int16_t input_xarcade_read(INP_XARC_DEV* const xdev) {
 	rd = read(xdev->fevdev, xdev->ev, sizeof(struct input_event) * 64);
 	if (rd < 0)
 		return -errno;
-	return rd;
+	return (rd / sizeof(struct input_event));
 }
 
 int16_t input_xarcade_close(INP_XARC_DEV* const xdev) {


### PR DESCRIPTION
The return value is used in the main loop and will cause issues if a lot of
events are generated. Problem introduced on:

a8ef225bbc2db2e452dbd4ab521a4fab77bd32d3 input: exit when input device doesn't exist anymore

Sorry about that.