### PR TITLE
gamepad: create different names for each device

### DIFF
--- a/src/input_xarcade.c
+++ b/src/input_xarcade.c
@@ -77,7 +77,7 @@ int findXarcadeDevice(void) {
 		ioctl(fevdev, EVIOCGNAME(sizeof(name)), name);
 		if ((strcmp(name, "XGaming X-Arcade") == 0)
 		    || (strcmp(name, "XGaming USBAdapter") == 0)) {
-			printf("Found %s (%s)\n", charbuffer, name);
+			printf("Found %s (%s)\n", filename, name);
 			break;
 		} else {
 			close(fevdev);

--- a/src/uinput_gamepad.c
+++ b/src/uinput_gamepad.c
@@ -49,7 +49,8 @@ static void send_key_event(int fd, unsigned int keycode, int keyvalue,
 }
 
 /* Setup the uinput device */
-int16_t uinput_gpad_open(UINP_GPAD_DEV* const gpad, UINPUT_GPAD_TYPE_E type) {
+int16_t uinput_gpad_open(UINP_GPAD_DEV* const gpad, UINPUT_GPAD_TYPE_E type,
+			 unsigned char number) {
 	int16_t uinp_fd = -1;
 	gpad->fd = open("/dev/uinput", O_WRONLY | O_NDELAY);
 	if (gpad->fd <= 0) {
@@ -59,8 +60,7 @@ int16_t uinput_gpad_open(UINP_GPAD_DEV* const gpad, UINPUT_GPAD_TYPE_E type) {
 
 	struct uinput_user_dev uinp;
 	memset(&uinp, 0, sizeof(uinp));
-	strncpy(uinp.name, "Xarcade-to-Gamepad Device",
-			strlen("Xarcade-to-Gamepad Device"));
+	snprintf(uinp.name, sizeof(uinp.name), "Xarcade-to-Gamepad Device %i", number);
 	uinp.id.version = 4;
 	uinp.id.bustype = BUS_USB;
 	uinp.id.product = 1;

--- a/src/uinput_gamepad.h
+++ b/src/uinput_gamepad.h
@@ -32,7 +32,8 @@ typedef struct {
 	int16_t state;
 } UINP_GPAD_DEV;
 
-int16_t uinput_gpad_open(UINP_GPAD_DEV* const gpad, UINPUT_GPAD_TYPE_E type);
+int16_t uinput_gpad_open(UINP_GPAD_DEV* const gpad, UINPUT_GPAD_TYPE_E type,
+			 unsigned char number);
 int16_t uinput_gpad_close(UINP_GPAD_DEV* const gpad);
 int16_t uinput_gpad_write(UINP_GPAD_DEV* const gpad, uint16_t keycode,
 		int16_t keyvalue, uint16_t evtype);


### PR DESCRIPTION
To better distinguish which device is which and keep the application
from reordering (Lakka), add the number of the device to the name.
