### PR TITLE
Add systemd support

### DIFF
--- a/scripts/xarcade2jstick
+++ b/scripts/xarcade2jstick
@@ -45,9 +45,9 @@ do_start()
 	#   0 if daemon has been started
 	#   1 if daemon was already running
 	#   2 if daemon could not be started
-	start-stop-daemon --start --quiet --pidfile $PIDFILE --make-pidfile --exec $DAEMON --test > /dev/null \
+	start-stop-daemon -b --start --quiet --pidfile $PIDFILE --make-pidfile --exec $DAEMON --test > /dev/null \
 		|| return 1
-	start-stop-daemon --start --quiet --pidfile $PIDFILE --make-pidfile --exec $DAEMON -- \
+	start-stop-daemon -b --start --quiet --pidfile $PIDFILE --make-pidfile --exec $DAEMON -- \
 		$DAEMON_ARGS \
 		|| return 2
 	# Add code here, if necessary, that waits for the process to be ready

--- a/src/80-xarcade.rules
+++ b/src/80-xarcade.rules
@@ -1,1 +1,1 @@
-SUBSYSTEM=="input", ATTRS{idVendor} == "aa55", ATTRS{idProduct} == "0101", RUN += "/usr/local/bin/xarcade2jstick -d"
+ACTION=="add", SUBSYSTEM=="input", ATTRS{idVendor} == "aa55", ATTRS{idProduct} == "0101", RUN += "/usr/local/bin/xarcade2jstick -d"

--- a/src/80-xarcade.rules
+++ b/src/80-xarcade.rules
@@ -1,1 +1,1 @@
-SUBSYSTEM=="input", ATTRS{idVendor} == "aa55", ATTRS{idProduct} == "0101", RUN += "/usr/local/bin/xarcade2jstick"
+SUBSYSTEM=="input", ATTRS{idVendor} == "aa55", ATTRS{idProduct} == "0101", RUN += "/usr/local/bin/xarcade2jstick -d"

--- a/src/80-xarcade.rules
+++ b/src/80-xarcade.rules
@@ -1,1 +1,5 @@
-ACTION=="add", SUBSYSTEM=="input", ATTRS{idVendor} == "aa55", ATTRS{idProduct} == "0101", RUN += "/usr/local/bin/xarcade2jstick -d"
+# Raspbian Jessie
+ACTION=="add", SUBSYSTEM=="input", ATTRS{idVendor}=="aa55", ATTRS{idProduct}=="0101", TEST=="/bin/systemd", TAG+="systemd", ENV{SYSTEMD_WANTS}+="xarcade2jstick.service"
+
+# Raspbian Wheezy
+ACTION=="add", SUBSYSTEM=="input", ATTRS{idVendor}=="aa55", ATTRS{idProduct}=="0101", TEST!="/bin/systemd", RUN+="/usr/local/bin/xarcade2jstick -d"

--- a/src/Makefile
+++ b/src/Makefile
@@ -30,7 +30,9 @@ install: all
 	install -d $(DESTDIR)$(bindir)
 	install -m 0755 $(TARGET) $(DESTDIR)$(bindir)
 	install -d $(DESTDIR)/lib/udev/rules.d/
-	install 80-xarcade.rules $(DESTDIR)/lib/udev/rules.d/
+	install -m 0644 80-xarcade.rules $(DESTDIR)/lib/udev/rules.d/
+	install -d $(DESTDIR)/lib/systemd/system/
+	install -m 0644 xarcade2jstick.service $(DESTDIR)/lib/systemd/system/
 
 uninstall:
 	-rm $(DESTDIR)$(bindir)/$(TARGET)

--- a/src/main.c
+++ b/src/main.c
@@ -49,6 +49,20 @@ int main(int argc, char* argv[]) {
 	int rd, ctr, combo = 0;
 	char keyStates[256];
 
+	int detach = 0;
+	int opt;
+	while ((opt = getopt(argc, argv, "+d")) != -1) {
+		switch (opt) {
+			case 'd':
+				detach = 1;
+				break;
+			default:
+				fprintf(stderr, "Usage: %s [-d]\n", argv[0]);
+				exit(1);
+				break;
+		}
+	}
+
 	printf("[Xarcade2Joystick] Getting exclusive access: ");
 	result = input_xarcade_open(&xarcdev, INPUT_XARC_TYPE_TANKSTICK);
 	printf("%s\n", (result == 0) ? "SUCCESS" : "FAILURE");
@@ -60,9 +74,11 @@ int main(int argc, char* argv[]) {
 	uinput_gpad_open(&uinp_gpads[1], UINPUT_GPAD_TYPE_XARCADE);
 	uinput_kbd_open(&uinp_kbd);
 
-	if (daemon(0, 1)) {
-		perror("daemon");
-		return 1;
+	if (detach) {
+		if (daemon(0, 1)) {
+			perror("daemon");
+			return 1;
+		}
 	}
 
 	while (1) {

--- a/src/xarcade2jstick.service
+++ b/src/xarcade2jstick.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Xarcade2Jstick
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/xarcade2jstick


### PR DESCRIPTION
Udev isn't supposed to run long running programs, even if they detach. As of Jessie the program is terminated once event handling ends, so our old approach of running xarcade2jstick no longer works.

See http://www.freedesktop.org/software/systemd/man/udev.html
> Starting daemons or other long-running processes is not appropriate for udev; the forked processes, detached or not, will be unconditionally killed after the event handling has finished.

This commit adds a systemd service, which appears to be the preferred way around this change in udev, and detects whether systemd is installed (but doesn't detect if it's in use) and chooses whether to use the old way or the systemd way to launch xarcade2jstick. Therefore xarcade2jstick continues to work on RetroPie 3.3 (Wheezy) and 3.4 (Jessie); I have tested this!

Also changed in this PR; xarcade2jstick no longer detaches by default; instead I've added a `-d` switch. This restores the old default behaviour, before detach was added in 665bd1e.

Also the udev rule is now only triggered when the device is attached, not detached, for a small optimisation.

See #20 for more details.