### PR TITLE
Key combinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@ _Xarcade2Jstick_ exclusively captures the keyboard events of the __Xarcade Tanks
 
 _Xarcade2Jstick_ was originally written as a supplementary tool for the [RetroPie Project](http://blog.petrockblock.com/retropie/). Using this tool allows the usage of the auto-config capability of [RetroArch](http://themaister.net/retroarch.html), a central component of a RetroPie installation.
 
+## Usage
+
+Your Xarcade will appear as two gamepads and can be used accordingly. There are also some special combinations of buttons that have special meaning:
+
+* P1 start + P2 start = TAB
+* P1 select + P2 select = ESC (the front side buttons)
+* P1 select + P1 start = 5
+* P2 select + P2 start = 6
+
 ## Downloading
 
 If you would like to download the current version of _Xarcade2Jstick_ from [its Github repository](https://github.com/petrockblog/Xarcade2Joystick), you can use this command:

--- a/src/main.c
+++ b/src/main.c
@@ -124,11 +124,21 @@ int main(int argc, char* argv[]) {
 						uinput_kbd_write(&uinp_kbd, KEY_5, 0, EV_KEY);
 						combo = 2;
 						continue;
+					} else if (keyStates[KEY_2] && xarcdev.ev[ctr].value) {
+						uinput_kbd_write(&uinp_kbd, KEY_TAB, 1, EV_KEY);
+						uinput_kbd_sleep();
+						uinput_kbd_write(&uinp_kbd, KEY_TAB, 0, EV_KEY);
+						combo = 2;
+						continue;
 					}
-					if (!combo)
-						uinput_gpad_write(&uinp_gpads[0], BTN_START,
-								xarcdev.ev[ctr].value > 0, EV_KEY);
-					else
+					/* it's a key down, ignore */
+					if (xarcdev.ev[ctr].value)
+						continue;
+					if (!combo) {
+						uinput_gpad_write(&uinp_gpads[0], BTN_START, 1, EV_KEY);
+						uinput_gpad_sleep();
+						uinput_gpad_write(&uinp_gpads[0], BTN_START, 0, EV_KEY);
+					} else
 						combo--;
 					break;
 				case KEY_3:
@@ -222,11 +232,21 @@ int main(int argc, char* argv[]) {
 						uinput_kbd_write(&uinp_kbd, KEY_6, 0, EV_KEY);
 						combo = 2;
 						continue;
+					} else if (keyStates[KEY_1] && xarcdev.ev[ctr].value) {
+						uinput_kbd_write(&uinp_kbd, KEY_TAB, 1, EV_KEY);
+						uinput_kbd_sleep();
+						uinput_kbd_write(&uinp_kbd, KEY_TAB, 0, EV_KEY);
+						combo = 2;
+						continue;
 					}
-					if (!combo)
-						uinput_gpad_write(&uinp_gpads[1], BTN_START,
-								xarcdev.ev[ctr].value > 0, EV_KEY);
-					else
+					/* it's a key down, ignore */
+					if (xarcdev.ev[ctr].value)
+						continue;
+					if (!combo) {
+						uinput_gpad_write(&uinp_gpads[1], BTN_START, 1, EV_KEY);
+						uinput_gpad_sleep();
+						uinput_gpad_write(&uinp_gpads[1], BTN_START, 0, EV_KEY);
+					} else
 						combo--;
 					break;
 				case KEY_4:

--- a/src/main.c
+++ b/src/main.c
@@ -119,9 +119,9 @@ int main(int argc, char* argv[]) {
 				case KEY_1:
 					/* handle combination */
 					if (keyStates[KEY_3] && xarcdev.ev[ctr].value) {
-						uinput_kbd_write(&uinp_kbd, KEY_6, 1, EV_KEY);
+						uinput_kbd_write(&uinp_kbd, KEY_5, 1, EV_KEY);
 						uinput_kbd_sleep();
-						uinput_kbd_write(&uinp_kbd, KEY_6, 0, EV_KEY);
+						uinput_kbd_write(&uinp_kbd, KEY_5, 0, EV_KEY);
 						combo = 2;
 						continue;
 					}
@@ -217,9 +217,9 @@ int main(int argc, char* argv[]) {
 				case KEY_2:
 					/* handle combination */
 					if (keyStates[KEY_4] && xarcdev.ev[ctr].value) {
-						uinput_kbd_write(&uinp_kbd, KEY_7, 1, EV_KEY);
+						uinput_kbd_write(&uinp_kbd, KEY_6, 1, EV_KEY);
 						uinput_kbd_sleep();
-						uinput_kbd_write(&uinp_kbd, KEY_7, 0, EV_KEY);
+						uinput_kbd_write(&uinp_kbd, KEY_6, 0, EV_KEY);
 						combo = 2;
 						continue;
 					}


### PR DESCRIPTION
Fixes #18. I have changes P1 select + start and P2 select + start to KEY_5 and KEY_6 respectively. I hope this is a popular / understandable change; I believe 5 and 6 are the standard coin buttons, at least in MAME. @aristeu you may have some more information here?

I have returned the TAB key, this time as the combo P1 start + P2 start. I have duplicated the code added by @aristeu to prevent button presses of P1 start or P2 start from going through if they are used in a combo.

I have included an update to the README to document the key combinations.