### PR TITLE
Change key combos

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ _Xarcade2Jstick_ was originally written as a supplementary tool for the [RetroPi
 
 Your Xarcade will appear as two gamepads and can be used accordingly. There are also some special combinations of buttons that have special meaning:
 
-* P1 start + P2 start = TAB
-* P1 select + P2 select = ESC (the front side buttons)
-* P1 select + P1 start = 5
-* P2 select + P2 start = 6
+* P1 select + P1 start = TAB
+* P2 select + P2 start = ESC
+
+The select buttons are the front buttons on each side of the joystick. The start buttons are the white top-center buttons.
 
 ## Downloading
 

--- a/src/main.c
+++ b/src/main.c
@@ -135,12 +135,6 @@ int main(int argc, char* argv[]) {
 				case KEY_1:
 					/* handle combination */
 					if (keyStates[KEY_3] && xarcdev.ev[ctr].value) {
-						uinput_kbd_write(&uinp_kbd, KEY_5, 1, EV_KEY);
-						uinput_kbd_sleep();
-						uinput_kbd_write(&uinp_kbd, KEY_5, 0, EV_KEY);
-						combo = 2;
-						continue;
-					} else if (keyStates[KEY_2] && xarcdev.ev[ctr].value) {
 						uinput_kbd_write(&uinp_kbd, KEY_TAB, 1, EV_KEY);
 						uinput_kbd_sleep();
 						uinput_kbd_write(&uinp_kbd, KEY_TAB, 0, EV_KEY);
@@ -158,20 +152,6 @@ int main(int argc, char* argv[]) {
 						combo--;
 					break;
 				case KEY_3:
-					/*
-					 * side buttons behave differently: they combine with other
-					 * keys so they only generate events on key up and no
-					 * valid combination was hit
-					 */
-					/* combination with the other side button, quit */
-					if (keyStates[KEY_3] && keyStates[KEY_4]) {
-						uinput_kbd_write(&uinp_kbd, KEY_ESC, 1, EV_KEY);
-						uinput_kbd_sleep();
-						uinput_kbd_write(&uinp_kbd, KEY_ESC, 0, EV_KEY);
-						keyStates[KEY_3] = keyStates[KEY_4] = 0;
-						combo = 2;
-						continue;
-					}
 					/* it's a key down, ignore */
 					if (xarcdev.ev[ctr].value)
 						continue;
@@ -243,15 +223,9 @@ int main(int argc, char* argv[]) {
 				case KEY_2:
 					/* handle combination */
 					if (keyStates[KEY_4] && xarcdev.ev[ctr].value) {
-						uinput_kbd_write(&uinp_kbd, KEY_6, 1, EV_KEY);
+						uinput_kbd_write(&uinp_kbd, KEY_ESC, 1, EV_KEY);
 						uinput_kbd_sleep();
-						uinput_kbd_write(&uinp_kbd, KEY_6, 0, EV_KEY);
-						combo = 2;
-						continue;
-					} else if (keyStates[KEY_1] && xarcdev.ev[ctr].value) {
-						uinput_kbd_write(&uinp_kbd, KEY_TAB, 1, EV_KEY);
-						uinput_kbd_sleep();
-						uinput_kbd_write(&uinp_kbd, KEY_TAB, 0, EV_KEY);
+						uinput_kbd_write(&uinp_kbd, KEY_ESC, 0, EV_KEY);
 						combo = 2;
 						continue;
 					}
@@ -266,20 +240,6 @@ int main(int argc, char* argv[]) {
 						combo--;
 					break;
 				case KEY_4:
-					/*
-					 * side buttons behave differently: they combine with other
-					 * keys so they only generate events on key up and no
-					 * valid combination was hit
-					 */
-					/* combination with the other side button, quit */
-					if (keyStates[KEY_3] && keyStates[KEY_4]) {
-						uinput_kbd_write(&uinp_kbd, KEY_ESC, 1, EV_KEY);
-						uinput_kbd_sleep();
-						uinput_kbd_write(&uinp_kbd, KEY_ESC, 0, EV_KEY);
-						keyStates[KEY_3] = keyStates[KEY_4] = 0;
-						combo = 2;
-						continue;
-					}
 					/* it's a key down, ignore */
 					if (xarcdev.ev[ctr].value)
 						continue;


### PR DESCRIPTION
Revert back to using just P1 keys in a combo, or P2 keys in a combo, but never a combo of P1 and P2. A combo of P1 and P2 is too easy for P1 and P2 to trigger together by accident! Such as both players pressing SELECT at the same time, or START at the same time.

This retains the logic that prevents combo usage from triggering its component keys.

Fixes #26 /cc @aristeu 