### PR TITLE
Add syslog and improve error handling / reporting

### DIFF
--- a/scripts/80-xarcade.rules
+++ b/scripts/80-xarcade.rules
@@ -2,4 +2,4 @@
 ACTION=="add", SUBSYSTEM=="input", ATTRS{idVendor}=="aa55", ATTRS{idProduct}=="0101", TEST=="/bin/systemd", TAG+="systemd", ENV{SYSTEMD_WANTS}+="xarcade2jstick.service"
 
 # Raspbian Wheezy
-ACTION=="add", SUBSYSTEM=="input", ATTRS{idVendor}=="aa55", ATTRS{idProduct}=="0101", TEST!="/bin/systemd", RUN+="/usr/local/bin/xarcade2jstick -d"
+ACTION=="add", SUBSYSTEM=="input", ATTRS{idVendor}=="aa55", ATTRS{idProduct}=="0101", TEST!="/bin/systemd", RUN+="/usr/local/bin/xarcade2jstick -d -s"

--- a/scripts/xarcade2jstick.service
+++ b/scripts/xarcade2jstick.service
@@ -3,4 +3,4 @@ Description=Xarcade2Jstick
 
 [Service]
 Type=oneshot
-ExecStart=/usr/local/bin/xarcade2jstick
+ExecStart=/usr/local/bin/xarcade2jstick -s

--- a/src/input_xarcade.c
+++ b/src/input_xarcade.c
@@ -29,8 +29,13 @@ int16_t input_xarcade_open(INP_XARC_DEV* const xdev, INPUT_XARC_TYPE_E type) {
 
 	// TODO check input parameter type
 	xdev->fevdev = findXarcadeDevice();
-	result = ioctl(xdev->fevdev, EVIOCGRAB, 1);
-	return result;
+	if (xdev->fevdev != -1) {
+		result = ioctl(xdev->fevdev, EVIOCGRAB, 1);
+		return result;
+	} else {
+		errno = 0;
+		return -1;
+	}
 }
 
 int16_t input_xarcade_read(INP_XARC_DEV* const xdev) {
@@ -81,6 +86,7 @@ int findXarcadeDevice(void) {
 			break;
 		} else {
 			close(fevdev);
+			fevdev = -1;
 		}
 	}
 	globfree(&pglob);

--- a/src/main.c
+++ b/src/main.c
@@ -58,16 +58,20 @@ int main(int argc, char* argv[]) {
 				break;
 			default:
 				fprintf(stderr, "Usage: %s [-d]\n", argv[0]);
-				exit(1);
+				exit(EXIT_FAILURE);
 				break;
 		}
 	}
 
 	printf("[Xarcade2Joystick] Getting exclusive access: ");
 	result = input_xarcade_open(&xarcdev, INPUT_XARC_TYPE_TANKSTICK);
-	printf("%s\n", (result == 0) ? "SUCCESS" : "FAILURE");
 	if (result != 0) {
-		exit(-1);
+		if (errno == 0) {
+			printf("Not found.\n");
+		} else {
+			printf("Failed to get exclusive access to Xarcade: %d (%s)\n", errno, strerror(errno));
+		}
+		exit(EXIT_FAILURE);
 	}
 
 	uinput_gpad_open(&uinp_gpads[0], UINPUT_GPAD_TYPE_XARCADE);
@@ -322,5 +326,5 @@ int main(int argc, char* argv[]) {
 	uinput_gpad_close(&uinp_gpads[0]);
 	uinput_gpad_close(&uinp_gpads[1]);
 	uinput_kbd_close(&uinp_kbd);
-	return 0;
+	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
It's quite nice to know what Xarcade2Jstick is doing, I think, and given that it runs away in the background usually, I've added syslog support. I think the startup printf logging can be improved as well; it currently logs the "Found <device name>" on the end of the "[Xarcade2Joystick] Getting exclusive access: " line... as it isn't usually run as a service I think we could also look at changing that around a little to still provide feedback when run interactively (which is the likely use-case when debugging).

I added signal handling as well so we see syslog entries about why the process died, and so we can nicely close the devices.