### PR TITLE
Fix the build following d1647242ed9d40fba8ddfd005e809fdee099302f

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -90,8 +90,8 @@ int main(int argc, char* argv[]) {
 
 	SYSLOG(LOG_NOTICE, "Got exclusive access to Xarcade.");
 
-	uinput_gpad_open(&uinp_gpads[0], UINPUT_GPAD_TYPE_XARCADE);
-	uinput_gpad_open(&uinp_gpads[1], UINPUT_GPAD_TYPE_XARCADE);
+	uinput_gpad_open(&uinp_gpads[0], UINPUT_GPAD_TYPE_XARCADE, 1);
+	uinput_gpad_open(&uinp_gpads[1], UINPUT_GPAD_TYPE_XARCADE, 2);
 	uinput_kbd_open(&uinp_kbd);
 
 	if (detach) {


### PR DESCRIPTION
The source doesn't currently compile. This fixes it.

For some reason these numbers were missing from the `device_names` branch. I've numbered them 1 and 2, rather than 0 and 1 as these numbers are visible to the user, so it seems nice to be friendly?