### PR TITLE
Add systemd startup slot for service

### DIFF
--- a/scripts/xarcade2jstick.service
+++ b/scripts/xarcade2jstick.service
@@ -4,3 +4,6 @@ Description=Xarcade2Jstick
 [Service]
 Type=oneshot
 ExecStart=/usr/local/bin/xarcade2jstick -s
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Let SystemD know when we want to start the service. The service file won't work without it. Fixes issue https://github.com/petrockblog/Xarcade2Jstick/issues/34
