### PR TITLE
Removed combos from start and select buttons so they can be used as Retropie 4.3 hotkeys.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,6 @@ _Xarcade2Jstick_ was originally written as a supplementary tool for the [RetroPi
 
 Your Xarcade will appear as two gamepads and can be used accordingly. There are also some special combinations of buttons that have special meaning:
 
-* P1 select + P1 start = TAB
-* P2 select + P2 start = ESC
-
 The select buttons are the front buttons on each side of the joystick. The start buttons are the white top-center buttons.
 
 ## Downloading

--- a/src/main.c
+++ b/src/main.c
@@ -53,7 +53,7 @@ static void signal_handler(int signum);
 
 int main(int argc, char* argv[]) {
 	int result = 0;
-	int rd, ctr, combo = 0;
+	int rd, ctr = 0;
 	char keyStates[256];
 
 	int detach = 0;
@@ -157,35 +157,12 @@ int main(int argc, char* argv[]) {
 							xarcdev.ev[ctr].value > 0, EV_KEY);
 					break;
 				case KEY_1:
-					/* handle combination */
-					if (keyStates[KEY_3] && xarcdev.ev[ctr].value) {
-						uinput_kbd_write(&uinp_kbd, KEY_TAB, 1, EV_KEY);
-						uinput_kbd_sleep();
-						uinput_kbd_write(&uinp_kbd, KEY_TAB, 0, EV_KEY);
-						combo = 2;
-						continue;
-					}
-					/* it's a key down, ignore */
-					if (xarcdev.ev[ctr].value)
-						continue;
-					if (!combo) {
-						uinput_gpad_write(&uinp_gpads[0], BTN_START, 1, EV_KEY);
-						uinput_gpad_sleep();
-						uinput_gpad_write(&uinp_gpads[0], BTN_START, 0, EV_KEY);
-					} else
-						combo--;
+					uinput_gpad_write(&uinp_gpads[0], BTN_START,
+						xarcdev.ev[ctr].value > 0, EV_KEY);
 					break;
 				case KEY_3:
-					/* it's a key down, ignore */
-					if (xarcdev.ev[ctr].value)
-						continue;
-					if (!combo) {
-						uinput_gpad_write(&uinp_gpads[0], BTN_SELECT, 1, EV_KEY);
-						uinput_gpad_sleep();
-						uinput_gpad_write(&uinp_gpads[0], BTN_SELECT, 0, EV_KEY);
-					} else
-						combo--;
-
+					uinput_gpad_write(&uinp_gpads[0], BTN_SELECT,
+						xarcdev.ev[ctr].value > 0, EV_KEY);
 					break;
 
 					/* joystick */
@@ -245,35 +222,12 @@ int main(int argc, char* argv[]) {
 							xarcdev.ev[ctr].value > 0, EV_KEY);
 					break;
 				case KEY_2:
-					/* handle combination */
-					if (keyStates[KEY_4] && xarcdev.ev[ctr].value) {
-						uinput_kbd_write(&uinp_kbd, KEY_ESC, 1, EV_KEY);
-						uinput_kbd_sleep();
-						uinput_kbd_write(&uinp_kbd, KEY_ESC, 0, EV_KEY);
-						combo = 2;
-						continue;
-					}
-					/* it's a key down, ignore */
-					if (xarcdev.ev[ctr].value)
-						continue;
-					if (!combo) {
-						uinput_gpad_write(&uinp_gpads[1], BTN_START, 1, EV_KEY);
-						uinput_gpad_sleep();
-						uinput_gpad_write(&uinp_gpads[1], BTN_START, 0, EV_KEY);
-					} else
-						combo--;
+					uinput_gpad_write(&uinp_gpads[1], BTN_START,
+						xarcdev.ev[ctr].value > 0, EV_KEY);
 					break;
 				case KEY_4:
-					/* it's a key down, ignore */
-					if (xarcdev.ev[ctr].value)
-						continue;
-					if (!combo) {
-						uinput_gpad_write(&uinp_gpads[1], BTN_SELECT, 1, EV_KEY);
-						uinput_gpad_sleep();
-						uinput_gpad_write(&uinp_gpads[1], BTN_SELECT, 0, EV_KEY);
-					} else
-						combo--;
-
+					uinput_gpad_write(&uinp_gpads[1], BTN_SELECT,
+						xarcdev.ev[ctr].value > 0, EV_KEY);
 					break;
 
 					/* joystick */
@@ -308,7 +262,7 @@ int main(int argc, char* argv[]) {
 static void teardown() {
 	printf("Exiting.\n");
 	SYSLOG(LOG_NOTICE, "Exiting.");
-	
+
 	input_xarcade_close(&xarcdev);
 	uinput_gpad_close(&uinp_gpads[0]);
 	uinput_gpad_close(&uinp_gpads[1]);


### PR DESCRIPTION
The TAB/ESC combos for P1/P2 start + select buttons have been removed and behave like any other button. This allows select to be assigned as a hotkey, introduced in Retropie 4.3. For example, holding select + start will exit game running on a libretro core.