### PR TITLE
X-Arcade Tri-Mode PCB support

### DIFF
--- a/src/input_xarcade.c
+++ b/src/input_xarcade.c
@@ -81,7 +81,8 @@ int findXarcadeDevice(void) {
 
 		ioctl(fevdev, EVIOCGNAME(sizeof(name)), name);
 		if ((strcmp(name, "XGaming X-Arcade") == 0)
-		    || (strcmp(name, "Ultimarc") == 0) 
+		    || (strcmp(name, "XGaming X-Arcade 2") == 0)
+		    || (strcmp(name, "Ultimarc") == 0)
 		    || (strcmp(name, "XGaming USBAdapter") == 0)) {
 			printf("Found %s (%s)\n", filename, name);
 			break;


### PR DESCRIPTION
The newest X-Arcade board contains a different product name and was failing to install. This board is the X-ARCADE ZEROLAG TRI-MODE USB UPGRADE KIT, and will also be the board included in the tank sticks and arcade stand-ups made by X-Arcade in 2019+.