### PR TITLE
Updated button combos

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ _Xarcade2Jstick_ was originally written as a supplementary tool for the [RetroPi
 
 Your Xarcade will appear as two gamepads and can be used accordingly. There are also some special combinations of buttons that have special meaning:
 
-* P1 select + P1 start = TAB
-* P2 select + P2 start = ESC
+* P1 Start + P1 Button0 = P1 Select (coin 1)
+* P2 Start + P2 Button0 = P2 Select (coin 2)
+* P1 Start + P2 Start = ESC (exit game)
+* P1 Start + P1 Right = TAB (toggle MAME menu)
 
-The select buttons are the front buttons on each side of the joystick. The start buttons are the white top-center buttons.
+The start buttons are the white top-center buttons.
 
 ## Downloading
 

--- a/src/main.c
+++ b/src/main.c
@@ -55,7 +55,7 @@ int main(int argc, char* argv[]) {
 	int result = 0;
 	int rd, ctr, combo = 0;
 	char keyStates[256];
-	memset(keyStates, 0, 256);
+	memset(keyStates, 0, sizeof(keyStates));
 	int detach = 0;
 	int opt;
 	while ((opt = getopt(argc, argv, "+ds")) != -1) {

--- a/src/main.c
+++ b/src/main.c
@@ -145,7 +145,6 @@ int main(int argc, char* argv[]) {
 					}
 					else
 					{
-
 						outputKeyPress(0,BTN_A, isPressed);
 					}
 					break;
@@ -175,9 +174,6 @@ int main(int argc, char* argv[]) {
 					if (isPressed)
 						continue;
 
-					/* Ensure P1Select is released it could get stuck if start is released before BTN_A */
-					outputKeyPress(0,BTN_SELECT, 0);
-
 					if (!comboP1)
 					{
 						outputKeyPress(0,BTN_START, 1);
@@ -185,7 +181,11 @@ int main(int argc, char* argv[]) {
 						outputKeyPress(0,BTN_START, 0);
 					}
 					else
+					{
+						/* Ensure P1Select is released it could get stuck if start is released before BTN_A */
+						outputKeyPress(0,BTN_SELECT, 0);
 						comboP1 = 0;
+					}
 					break;
 				case KEY_3:
 					outputKeyPress(0,BTN_SELECT, isPressed);
@@ -196,7 +196,16 @@ int main(int argc, char* argv[]) {
 					break;
 				case KEY_KP6:
 				case KEY_RIGHT:
-					outputAxisChange(0,ABS_X,	value == 0 ? 2 : 4); // center or right
+					/* P1Start + P1Right = Tab */
+					if (keyStates[KEY_1])
+					{
+						uinput_kbd_write(&uinp_kbd, KEY_TAB, isPressed, EV_KEY);
+						comboP1 = 1;
+					}
+					else
+					{
+						outputAxisChange(0,ABS_X,	value == 0 ? 2 : 4); // center or right
+					}
 					break;
 				case KEY_KP8:
 				case KEY_UP:
@@ -256,9 +265,6 @@ int main(int argc, char* argv[]) {
 						if (isPressed)
 							continue;
 
-						/* Ensure P2Select is released it could get stuck if start is released before BTN_A */
-						outputKeyPress(1,BTN_SELECT, 0);
-
 						if (!comboP2)
 						{
 							outputKeyPress(1,BTN_START, 1);
@@ -266,7 +272,11 @@ int main(int argc, char* argv[]) {
 							outputKeyPress(1,BTN_START, 0);
 						}
 						else
+						{
+							/* Ensure P2Select is released it could get stuck if start is released before BTN_A */
+							outputKeyPress(1,BTN_SELECT, 0);
 							comboP2 = 0;
+						}
 					}
 					break;
 				case KEY_4:

--- a/src/uinput_gamepad.c
+++ b/src/uinput_gamepad.c
@@ -81,6 +81,7 @@ int16_t uinput_gpad_open(UINP_GPAD_DEV* const gpad, UINPUT_GPAD_TYPE_E type,
 	ioctl(gpad->fd, UI_SET_KEYBIT, BTN_TR);
 	ioctl(gpad->fd, UI_SET_KEYBIT, BTN_SELECT);
 	ioctl(gpad->fd, UI_SET_KEYBIT, BTN_START);
+	ioctl(gpad->fd, UI_SET_KEYBIT, BTN_MODE);
 
 	// gamepad, directions
 	ioctl(gpad->fd, UI_SET_EVBIT, EV_ABS);

--- a/src/uinput_gamepad.c
+++ b/src/uinput_gamepad.c
@@ -81,7 +81,6 @@ int16_t uinput_gpad_open(UINP_GPAD_DEV* const gpad, UINPUT_GPAD_TYPE_E type,
 	ioctl(gpad->fd, UI_SET_KEYBIT, BTN_TR);
 	ioctl(gpad->fd, UI_SET_KEYBIT, BTN_SELECT);
 	ioctl(gpad->fd, UI_SET_KEYBIT, BTN_START);
-	ioctl(gpad->fd, UI_SET_KEYBIT, BTN_MODE);
 
 	// gamepad, directions
 	ioctl(gpad->fd, UI_SET_EVBIT, EV_ABS);


### PR DESCRIPTION
These changes include updated button combos for systems where the select buttons are not accessible, i.e. when they are connected to the coin door for P1 & P2 coin entry.

**Button combos are:**
- _P1Start + P1Button0 = P1Select (or P1Coin)_
- _P2Start + P2Button0 = P2Select (or P2Coin)_
- _P1Start + P2Start = ESC_
- _P1Start + P1Right = TAB_

No pressure to take these changes, and I realize I have removed the old combos which may cause problems for existing users, but I thought I'd offer them up just in case you think they're useful.
